### PR TITLE
Fix completions

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ Loop:
 		}
 
 		switch {
+		case arg == "__complete" || arg == "__completeNoDesc":
+			break Loop
+
 		case arg == "--help" || arg == "-h":
 			displayHelp = true
 			continue


### PR DESCRIPTION
Fixes completions by not filtering out the internal `__complete` or `__completeNoDesc` cobra commands.