### PR TITLE
Don't require a `scripts` field in package.json

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -23,7 +23,7 @@ func runScript(name string, args []string) error {
 	}
 
 	if pkg.Scripts == nil {
-		return fmt.Errorf("No scripts found")
+		pkg.Scripts = &map[string]string{}
 	}
 
 	binDirs := findBinDirs(cwd)


### PR DESCRIPTION
This makes it so that `run` works without a `scripts` field in package.json. There may be other installed modules that have bin files.